### PR TITLE
Feature: Require maskingTypes for columns

### DIFF
--- a/config/lint.go
+++ b/config/lint.go
@@ -715,9 +715,10 @@ T:
 
 // ◆ マスキング種別必須ルール ----------------------------------------------
 type RequireMaskingTypes struct {
-	Enabled      bool     `yaml:"enabled"`
-	AllOrNothing bool     `yaml:"allOrNothing"`
-	Exclude      []string `yaml:"exclude"`
+	Enabled       bool     `yaml:"enabled"`
+	AllOrNothing  bool     `yaml:"allOrNothing"`
+	Exclude       []string `yaml:"exclude"`
+	ExcludeTables []string `yaml:"excludeTables"`
 }
 
 func (r RequireMaskingTypes) IsEnabled() bool { return r.Enabled }
@@ -736,7 +737,7 @@ func (r RequireMaskingTypes) Check(s *schema.Schema, exclude []string) []RuleWar
 	msgMissing := "maskingTypes required."
 	msgInvalid := "invalid maskingType '%s'. (allowed: salon_id, random, none)"
 
-	nt := s.NormalizeTableNames(r.Exclude)
+	nt := s.NormalizeTableNames(r.ExcludeTables)
 	exists := false
 
 	for _, t := range s.Tables {
@@ -745,6 +746,9 @@ func (r RequireMaskingTypes) Check(s *schema.Schema, exclude []string) []RuleWar
 		}
 		for _, c := range t.Columns {
 			target := fmt.Sprintf("%s.%s", t.Name, c.Name)
+			if match(r.Exclude, c.Name) || match(r.Exclude, target) {
+				continue
+			}
 			if c.MaskingType == "" {
 				warns = append(warns, RuleWarn{Target: target, Message: msgMissing})
 				continue

--- a/config/lint.go
+++ b/config/lint.go
@@ -24,6 +24,8 @@ type Lint struct {
 	RequireForeignKeyIndex   RequireForeignKeyIndex   `yaml:"requireForeignKeyIndex"`
 	LabelStyleBigQuery       LabelStyleBigQuery       `yaml:"labelStyleBigQuery"`
 	RequireViewpoints        RequireViewpoints        `yaml:"requireViewpoints"`
+	// ◆ 追加
+	RequireMaskingTypes      RequireMaskingTypes      `yaml:"requireMaskingTypes"`
 }
 
 // RuleWarn is struct of Rule error.
@@ -708,5 +710,57 @@ T:
 		})
 	}
 
+	return warns
+}
+
+// ◆ マスキング種別必須ルール ----------------------------------------------
+type RequireMaskingTypes struct {
+	Enabled      bool     `yaml:"enabled"`
+	AllOrNothing bool     `yaml:"allOrNothing"`
+	Exclude      []string `yaml:"exclude"`
+}
+
+func (r RequireMaskingTypes) IsEnabled() bool { return r.Enabled }
+
+var allowedMaskingTypes = map[string]struct{}{
+	"salon_id": {},
+	"random":   {},
+	"none":     {},
+}
+
+func (r RequireMaskingTypes) Check(s *schema.Schema, exclude []string) []RuleWarn {
+	if !r.IsEnabled() {
+		return nil
+	}
+	warns := []RuleWarn{}
+	msgMissing := "maskingTypes required."
+	msgInvalid := "invalid maskingType '%s'. (allowed: salon_id, random, none)"
+
+	nt := s.NormalizeTableNames(r.Exclude)
+	exists := false
+
+	for _, t := range s.Tables {
+		if match(exclude, t.Name) || match(nt, t.Name) {
+			continue
+		}
+		for _, c := range t.Columns {
+			target := fmt.Sprintf("%s.%s", t.Name, c.Name)
+			if c.MaskingType == "" {
+				warns = append(warns, RuleWarn{Target: target, Message: msgMissing})
+				continue
+			}
+			if _, ok := allowedMaskingTypes[c.MaskingType]; !ok {
+				warns = append(warns, RuleWarn{
+					Target:  target,
+					Message: fmt.Sprintf(msgInvalid, c.MaskingType),
+				})
+				continue
+			}
+			exists = true
+		}
+	}
+	if r.AllOrNothing && !exists {
+		return nil
+	}
 	return warns
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/k1LoW/tbls
+module github.com/SouhlInc/tbls
 
 go 1.23.8
 

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -120,7 +120,9 @@ type Column struct {
 	Type            string
 	Nullable        bool
 	Default         sql.NullString
-	Comment         string
+	Comment         string `json:"comment,omitempty"`
+	// ドキュメント用マスキング種別（lint で必須）
+	MaskingType     string `json:"maskingType,omitempty" yaml:"maskingType,omitempty"`
 	ExtraDef        string
 	Occurrences     sql.NullInt32
 	Percents        sql.NullFloat64


### PR DESCRIPTION
Add a new lint rule to require `maskingType` for all columns and ensure its value is one of 'salon_id', 'random', or 'none'.

This PR includes the following changes:

1.  **schema/schema.go**: Added `MaskingType` field to the `Column` struct.
2.  **config/config.go**: 
    *   Added `MaskingTypes` field to the `AdditionalComment` struct.
    *   Added logic to `mergeAdditionalComments` to handle and validate `maskingTypes`.
3.  **config/lint.go**:
    *   Added `RequireMaskingTypes` to the `Lint` struct.
    *   Implemented the `RequireMaskingTypes` lint rule.